### PR TITLE
compare datafields without sf omissions

### DIFF
--- a/MARC_set_wrangler.rb
+++ b/MARC_set_wrangler.rb
@@ -482,6 +482,8 @@ def get_fields_for_comparison(rec, config)
             end
           }
           compare << newfield
+        else
+          compare << cf
         end
       end
     end


### PR DESCRIPTION
When there are fields with specific subfields omitted from comparison
  example settings:  {omit from comparison subfields: { '040': 'cd'}}
we seem to be skipping comparison of DataFields that are that not one of the compare-some-subfields-only fields; i.e. only comparing non-excluded ControlFields, and DataFields with subfields omitted.