### PR TITLE
Add subcollections

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    marc_wrangler (0.1.0)
+    marc_wrangler (0.1.2)
       enhanced_marc (~> 0.3.2)
       highline (~> 2.0.1)
       marc (~> 1.0.2)
@@ -13,9 +13,9 @@ GEM
     enhanced_marc (0.3.2)
       locale
       marc
-    highline (2.0.1)
+    highline (2.0.2)
     locale (2.1.2)
-    marc (1.0.2)
+    marc (1.0.4)
       scrub_rb (>= 1.0.1, < 2)
       unf
     rake (10.5.0)
@@ -35,7 +35,7 @@ GEM
     scrub_rb (1.0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
+    unf_ext (0.0.7.6)
 
 PLATFORMS
   ruby
@@ -47,4 +47,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.16.0
+   1.16.2

--- a/MARC_set_wrangler.rb
+++ b/MARC_set_wrangler.rb
@@ -3,6 +3,7 @@
 $LOAD_PATH << '.'
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'csv'
+require 'set'
 require 'yaml'
 require 'marc'
 require 'lib/marc_wrangler'
@@ -94,29 +95,34 @@ class Affix
     end
   end
 
-  def add_to_value(value)
+  def add_to_value(value, affix)
     case @type
     when 'prefix'
-      @affix + value
+      affix + value
     when 'suffix'
-      value + @affix
+      value + affix
     end
   end
 
-  def add_to_record(rec, id_elements)
+  # Passing an add_to_affix value allows for custom (e.g. per record or
+  # subcollection) data to be appended to the global affix. (Note that
+  # regardlessthe of whether the affix is a prefix or suffix,
+  # the add_to_affix value, if any, is always appended to the affix.
+  def add_to_record(rec, id_elements, add_to_affix: nil)
     id_elements.each do |ide|
       e = SpecifiedMarcElement.new(ide)
       if rec.tags.include?(e.tag)
         rec.find_all { |field| field.tag == e.tag }.each do |field|
-          case field.class.name
-          when 'MARC::ControlField'
-            field.value = add_to_value(field.value)
-          when 'MARC::DataField'
+          if field.is_a? MARC::ControlField
+            field.value = add_to_value(field.value, "#{@affix}#{add_to_affix}")
+          else
             clean_sfs = field.subfields.select { |sf| e.subfields.include?(sf.code) }
-            clean_sfs.each { |sf| sf.value = add_to_value(sf.value) }
+            clean_sfs.each do |sf|
+              sf.value = add_to_value(sf.value, "#{@affix}#{add_to_affix}")
           end
         end
       end
+    end
     end
     rec
   end
@@ -252,16 +258,31 @@ if thisconfig['flag AC recs with changed headings']
   end
 end
 
+subcollections =
+  if thisconfig['subcollection spec']
+    thisconfig['subcollection spec']['subcollections']
+  end
+
+if subcollections
+  if thisconfig['subcollection spec']['use subcoll name as id affix']
+    subcollections.each { |k, v| v['id affix value'] = k.to_s.freeze }
+  end
+end
+
+subcoll_fspec = thisconfig['subcollection spec']['set by'] if subcollections
+
 # Set affix if it's going to be used, otherwise it is blank string
 if thisconfig['use id affix']
   if idfields.size > 0
     unless thisconfig['affix type']
       abort("\n\nSCRIPT FAILURE!\nPROBLEM IN CONFIG FILE: If 'use id affix' = true, you need to specify 'affix type'\n\n")
     end
-    unless thisconfig['id affix value']
+    unless thisconfig['id affix value'] || subcollections
       abort("\n\nSCRIPT FAILURE!\nPROBLEM IN CONFIG FILE: If 'use id affix' = true, you need to specify 'id affix value'\n\n")
     end
+    if thisconfig['id affix value']
     puts "\n\nThe #{thisconfig['affix type']} #{thisconfig['id affix value']} will be added to #{idfields.join(', ')}."
+    end
     affix_handler = Affix.new(thisconfig['id affix value'], thisconfig['affix type'])
   else
     abort("\n\nSCRIPT FAILURE!\nPROBLEM IN CONFIG FILE: If 'use id affix' = true, you need to specify at least one of the following: 'main id', 'merge id'\n\n")
@@ -349,7 +370,7 @@ module Format
 end
 
 # Produces array of RecInfo structs from the MARC files in a directory
-def get_rec_info(dir, label)
+def get_rec_info(dir, label, subcollections: {}, subcoll_fspec: [])
   puts "\n\nGathering record info from #{dir} files:"
   recinfos = []
   infiles = Dir.glob("#{dir}/*.mrc")
@@ -383,6 +404,7 @@ def get_rec_info(dir, label)
       rec.fields.delete(rec['005']) if rec['005']
       ri.marc_hash = rec.to_s.hash
 
+      ri.subcollection = subcollection(rec, subcollections, subcoll_fspec)
       ri.mergeids = rec.m019_vals
       ri.sourcefile = file
 
@@ -396,36 +418,50 @@ end
 
 def make_rec_info_hash(ri_array)
   thehash = {}
-  ri_array.each { |ri|
-    if thehash.has_key?(ri.id)
-      thehash[ri.id] << ri
-    else
-      thehash[ri.id] = [ri]
-    end
-  }
+  ids_duplicated = Set.new
 
-  # Check for dupe records in set.
-  # If any are found, script stops
-  # Otherwise, all hash values are now just one RecordInfo object
-  ids_duplicated = []
-  thehash.each_pair { |id, ri_array|
-    if ri_array.size > 1
+  ri_array.each do |ri|
+    id = "#{ri.id}#{ri&.subcollection&.dig('id affix value')}"
+    if thehash.has_key?(id)
       ids_duplicated << id
     else
-      thehash[id] = ri_array[0]
+      thehash[id] = ri
     end
-  }
-
-  if ids_duplicated.size > 0
-    if thehash[ids_duplicated.first].first.is_a? MarcWrangler::ExistingRecordInfo
-      name = 'EXISTING'
-    else
-      name = 'INCOMING'
-    end
-    abort("\n\nSCRIPT FAILURE!\nDUPLICATE RECORDS IN #{name} RECORD FILE(S):\nMultiple records in your #{name.downcase} record file(s) have the same 001 value(s).\nAffected 001 values: #{ids_duplicated.join(', ')}\nPlease de-duplicate your #{name.downcase} file(s) and try the script again.\n\n")
-  else
-    return thehash
   end
+
+  # Check for dupe records in set.
+  # If any are found, script stops.
+  return thehash if ids_duplicated.empty?
+
+  name = if thehash[ids_duplicated.first].is_a? MarcWrangler::ExistingRecordInfo
+           'EXISTING'
+    else
+           'INCOMING'
+    end
+  abort(
+    <<~EOL
+      \n\nSCRIPT FAILURE!
+      DUPLICATE RECORDS IN #{name} RECORD FILE(S):
+      Multiple records in your #{name.downcase} record file(s) have the same 001 value(s).
+      Affected 001 values: #{ids_duplicated.to_a.join(', ')}
+      Please de-duplicate your #{name.downcase} file(s) and try the script again.\n\n
+    EOL
+  )
+end
+
+def subcollection(rec, subcollections, fspec)
+  return if subcollections.empty?
+
+  find_spec = fspec['find']
+
+  fields = Config.get_fields_by_spec(rec.fields, [fspec])
+  fields.each do |f|
+    subcollections.each do |_, v|
+      return v if f.to_s =~ /#{v['value']}/
+    end
+  end
+
+  nil
 end
 
 def clean_id(rec, idfields, spec)
@@ -539,11 +575,15 @@ end
 
 # Pull in our incoming and, if relevant, previously loaded MARC records
 rec_info_sets = []
-in_rec_info = get_rec_info(in_dir, 'incoming')
+in_rec_info = get_rec_info(in_dir, 'incoming',
+                           subcollections: subcollections,
+                           subcoll_fspec: subcoll_fspec)
 rec_info_sets << in_rec_info
 
 if thisconfig['use existing record set']
-  ex_rec_info = get_rec_info(ex_dir, 'existing')
+  ex_rec_info = get_rec_info(ex_dir, 'existing',
+                             subcollections: subcollections,
+                             subcoll_fspec: subcoll_fspec)
   rec_info_sets << ex_rec_info
 end
 
@@ -622,9 +662,9 @@ until in_info.empty?
     processlog << [DateTime.now.to_s, ri.sourcefile, ri.id, 'begin processing MARC record']
   end
 
-  if thisconfig['use existing record set']
-    ex_ri = ri.ovdata.first if ri.ovdata.any?
-  end
+  ex_ri = ri.ovdata.first if thisconfig['use existing record set']
+
+  subcoll = ri&.subcollection
 
   if thisconfig['set record status by file diff']
     if ri.ovdata.any?
@@ -717,7 +757,8 @@ until in_info.empty?
   end
 
   if thisconfig['use id affix']
-    rec = affix_handler.add_to_record(rec, idfields)
+    addl_affix = ri&.subcollection&.dig('id affix value')
+    rec = affix_handler.add_to_record(rec, idfields, add_to_affix: addl_affix)
   end
 
   if thisconfig['flag rec status']
@@ -771,6 +812,17 @@ until in_info.empty?
   if thisconfig['add conditional MARC field with parameters spec']
     thisconfig['add conditional MARC field with parameters spec'].each do |field_spec|
       reced.add_conditional_field_with_parameters(field_spec)
+    end
+  end
+
+  if subcollections && ri.subcollection
+    add_specs = thisconfig['subcollection spec']['add']
+    add_specs.each do |add_spec|
+      replaces = ri.subcollection.
+                 reject { |k, _| k == 'value'}.
+                 to_a.
+                 map { |k,v| {k => v} }
+      reced.add_field_with_parameter([add_spec], replaces)
     end
   end
 
@@ -848,7 +900,8 @@ if thisconfig['produce delete file']
         end
 
         if thisconfig['use id affix']
-          del_rec = affix_handler.add_to_record(del_rec, idfields)
+          addl_affix = ri&.subcollection&.dig('id affix value')
+          del_rec = affix_handler.add_to_record(del_rec, idfields, add_to_affix: addl_affix)
         end
 
         dwriter.write(del_rec)

--- a/config.yaml
+++ b/config.yaml
@@ -369,14 +369,13 @@ collections:
   generic collection (no special collection-level processing):
     placeholder option: true
   WCM - CombinedMonthly (cross-collection):
-    id affix value: 'Combined'
     add MARC field spec:
       - tag: '773'
         i1: '1'
         i2: ' '
         subfields:
           - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. WCMcombined'
+            value: 'OCLC WorldShare Collection Manager managed collection. wcmCombined'
       - tag: '506'
         i1: '1'
         i2: ' '
@@ -385,115 +384,93 @@ collections:
             value: 'Access limited to UNC Chapel Hill-authenticated users.'
           - delimiter: 'f'
             value: 'Unlimited simultaneous users'
-    add conditional MARC field with parameters spec:
-      - find:
-          tag: '773'
-        add:
-          - tag: '590'
-            i1: '0'
-            i2: ' '
-            subfields:
-              - delimiter: 'a'
-                value: 'Content provider: provider_param.'
-        mappings:
-          - value: 'ACS symposium series.*(online collection)'
-            provider_param: 'American Chemical Society'
-          - value: 'AGU ebooks.*(online collection)'
-            provider_param: 'American Geophysical Union via Wiley Online Library'
-          - value: 'AIP Conference Proceedings.*(online collection)'
-            provider_param: 'American Institute of Physics'
-          - value: 'American Mathematical Society.*(online collection)'
-            provider_param: 'American Mathematical Society (AMS)'
-          - value: 'Business Expert Press.*(online collection)'
-            provider_param: 'IGPublish'
-          - value: 'Cambridge histories.*(online collection)'
-            provider_param: 'Cambridge University Press'
-          - value: 'Cambridge University Press.*(online collection)'
-            provider_param: 'Cambridge University Press'
-          - value: 'CIAO.*(online collection)'
-            provider_param: 'CIAO'
-          - value: 'Columbia University Press.*(online collection)'
-            provider_param: 'De Gruyter'
-          - value: 'Cornell University Press.*(online collection)'
-            provider_param: 'De Gruyter'
-          - value: 'Credo Academic.*(online collection)'
-            provider_param: 'Credo Reference'
-          - value: 'de Gruyter.*(online collection)'
-            provider_param: 'De Gruyter'
-          - value: 'European Mathematical Society.*(online collection)'
-            provider_param: 'European Mathematical Society'
-          - value: 'Film Platform.*(online collection)'
-            provider_param: 'Film Platform'
-          - value: 'GeoScienceWorld.*(online collection)'
-            provider_param: 'GeoScienceWorld'
-          - value: 'Harvard University Press.*(online collection)'
-            provider_param: 'De Gruyter'
-          - value: 'Medici.tv.*(online collection)'
-            provider_param: 'Medici.tv'
-          - value: 'Numerique premium.*(online collection)'
-            provider_param: 'Numerique Premium'
-          - value: 'Princeton University Press.*(online collection)'
-            provider_param: 'De Gruyter'
-          - value: 'Psychotherapy.net*(online collection)'
-            provider_param: 'Psychotheraphy.net'
-          - value: 'Royal Society of Chemistry.*(online collection)'
-            provider_param: 'Royal Society of Chemistry (Great Britain)'
-          - value: 'Rutgers University Press.*(online collection)'
-            provider_param: 'De Gruyter'
-          - value: 'SPIE ebooks.*(online collection)'
-            provider_param: 'SPIE'
-          - value: 'University of Hawaii.*(online collection)'
-            provider_param: 'De Gruyter'
-          - value: 'University of Pennsylvania.*(online collection)'
-            provider_param: 'De Gruyter'
-          - value: 'University of Toronto.*(online collection)'
-            provider_param: 'De Gruyter'
-  WCM - ACS:
-    id affix value: 'ACS'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. ACS'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: American Chemical Society.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - AIP:
-    id affix value: 'AIP'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. AIP'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: American Institute of Physics.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
+    subcollection spec:
+      set by:
+        tag: '773'
+      add:
+        - tag: '590'
+          i1: '0'
+          i2: ' '
+          subfields:
+            - delimiter: 'a'
+              value: 'Content provider: provider_param.'
+      use subcoll name as id affix: true
+      subcollections:
+        ACS:
+          value: 'ACS symposium series.*(online collection)'
+          provider_param: 'American Chemical Society'
+        AIP:
+          value: 'AIP conference proceedings.*(online collection)'
+          provider_param: 'American Institute of Physics'
+        AMS:
+          value: 'American Mathematical Society.*(online collection)'
+          provider_param: 'American Mathematical Society (AMS)'
+        BEP:
+          value: 'Business expert press.*(online collection)'
+          provider_param: 'IGPublish'
+        CHO:
+          value: 'Cambridge histories.*(online collection)'
+          provider_param: 'Cambridge University Press'
+        CIAO:
+          value: 'CIAO.*(online collection)'
+          provider_param: 'CIAO'
+        Credo:
+          value: 'Credo Academic.*(online collection)'
+          provider_param: 'Credo Reference'
+        CUP:
+          value: 'Cambridge University Press.*(online collection)'
+          provider_param: 'Cambridge University Press'
+        DGcolumbia:
+          value: 'Columbia University Press.*(online collection)'
+          provider_param: 'De Gruyter'
+        DGcornell:
+          value: 'Cornell University Press.*(online collection)'
+          provider_param: 'De Gruyter'
+        DGedition:
+          value: 'de Gruyter e-dition.*(online collection)'
+          provider_param: 'De Gruyter'
+        DGger:
+          value: 'de Gruyter ebooks.*(online collection).*German studies'
+          provider_param: 'De Gruyter'
+        DGharvard:
+          value: 'Harvard University Press.*(online collection)'
+          provider_param: 'De Gruyter'
+        DGhawaii:
+          value: 'University of Hawaii.*(online collection)'
+          provider_param: 'De Gruyter'
+        DGpenn:
+          value: 'University of Pennsylvania.*(online collection)'
+          provider_param: 'De Gruyter'
+        DGprinceton:
+          value: 'Princeton University Press.*(online collection)'
+          provider_param: 'De Gruyter'
+        DGrutgers:
+          value: 'Rutgers University Press.*(online collection)'
+          provider_param: 'De Gruyter'
+        DGtoronto:
+          value: 'University of Toronto.*(online collection)'
+          provider_param: 'De Gruyter'
+        FilmPlatform:
+          value: 'Film Platform.*(online collection)'
+          provider_param: 'Film Platform'
+        GSW:
+          value: 'GeoScienceWorld.*(online collection)'
+          provider_param: 'GeoScienceWorld'
+        Medici:
+          value: 'Medici.tv.*(online collection)'
+          provider_param: 'Medici.tv'
+        NumPrem:
+          value: 'Numerique premium.*(online collection)'
+          provider_param: 'Numerique Premium'
+        PsychNet:
+          value: 'Psychotherapy.net*(online collection)'
+          provider_param: 'Psychotheraphy.net'
+        RSC:
+          value: 'Royal Society of Chemistry.*(online collection)'
+          provider_param: 'Royal Society of Chemistry (Great Britain)'
+        SPIE:
+          value: 'SPIE ebooks.*(online collection)'
+          provider_param: 'SPIE'
   WCM - AGU:
     id affix value: 'AGU'
     add MARC field spec:
@@ -509,121 +486,6 @@ collections:
         subfields:
           - delimiter: 'a'
             value: 'Content provider: American Geophysical Union via Wiley Online Library.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - AMS:
-    id affix value: 'AMS'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. AMS'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: American Mathematical Society (AMS).'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - BEP:
-    id affix value: 'BEP'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. BEP'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: IGPublish.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - CHO:
-    id affix value: 'CHO'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. CHO'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: Cambridge University Press.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - CIAO:
-    id affix value: 'CIAO'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. CIAO'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: CIAO.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - Credo:
-    id affix value: 'Credo'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. Credo'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: Credo Reference.'
       - tag: '506'
         i1: '1'
         i2: ' '
@@ -656,331 +518,6 @@ collections:
             value: 'Access limited to UNC Chapel Hill-authenticated users.'
           - delimiter: 'f'
             value: 'Unlimited simultaneous users'
-  WCM - CUP:
-    clean ids:
-      - find: 'wcmcup'
-        replace: ''
-    id affix value: 'cup'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. CUP'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: Cambridge University Press.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - DGcolumbia:
-    id affix value: 'DGcolumbia'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. De Gruyter Columbia'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: De Gruyter.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - DGcornell:
-    id affix value: 'DGcornell'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. De Gruyter Cornell'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: De Gruyter.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - DGedition:
-    id affix value: 'DGedition'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. De Gruyter e-dition'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: De Gruyter.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - DGger:
-    id affix value: 'DGger'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. De Gruyter German Studies'
-      - tag: '590'
-        i1: ' '
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Provider: De Gruyter.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - DGharvard:
-    id affix value: 'DGharvard'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. DGharvard'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: De Gruyter.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - DGhawaii:
-    id affix value: 'DGhawaii'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. De Gruyter Hawaii'
-      - tag: '590'
-        i1: ' '
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Provider: De Gruyter.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - DGpenn:
-    id affix value: 'DGpenn'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. DGpenn'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: De Gruyter.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - DGprinceton:
-    id affix value: 'DGprinceton'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. De Gruyter Princeton'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: De Gruyter.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - EMS:
-    id affix value: 'EMS'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. EMS'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: European Mathematical Society.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - FilmPlatform:
-    id affix value: 'FilmPlatform'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. FilmPlatform'
-      - tag: '590'
-        i1: ' '
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Provider: Film Platform.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - GSW:
-    id affix value: 'GSW'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. GSW'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: GeoScienceWorld.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - Medici.tv:
-    id affix value: 'Medici'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. Medici'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: Medici.tv.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - NumPrem:
-    id affix value: 'NumPrem'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. Numerique Premium'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: Numerique Premium.'
   WCM - PsychNet:
     id affix value: 'PsychNet'
     add MARC field spec:
@@ -1004,52 +541,6 @@ collections:
         subfields:
           - delimiter: 'a'
             value: 'Content provider: Psychotheraphy.net.'
-  WCM - RSC:
-    id affix value: 'RSC'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. RSC'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: Royal Society of Chemistry (Great Britain).'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
-  WCM - SPIE:
-    id affix value: 'SPIE'
-    add MARC field spec:
-      - tag: '773'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 't'
-            value: 'OCLC WorldShare Collection Manager managed collection. SPIE'
-      - tag: '590'
-        i1: '0'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Content provider: SPIE.'
-      - tag: '506'
-        i1: '1'
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: 'Access limited to UNC Chapel Hill-authenticated users.'
-          - delimiter: 'f'
-            value: 'Unlimited simultaneous users'
   WCM - SPRnew:
     id affix value: 'SPRnew'
     add MARC field spec:

--- a/lib/marc_wrangler/record_info.rb
+++ b/lib/marc_wrangler/record_info.rb
@@ -23,6 +23,7 @@ module MarcWrangler
     attr_accessor :reader
     attr_accessor :reader_index
     attr_accessor :marc_hash
+    attr_accessor :subcollection
 
     def initialize(id)
       @id = id

--- a/lib/marc_wrangler/version.rb
+++ b/lib/marc_wrangler/version.rb
@@ -1,3 +1,3 @@
 module MarcWrangler
-  VERSION = "0.1.1"
+  VERSION = '0.1.2'.freeze
 end


### PR DESCRIPTION
- Add subcollections.
  - Incoming records can be grouped into subcollections based on whether specified fields match the subcollection's pattern.
  - Subcollections can have id affix's that are added to the institution/workflow/collection affix chain
  - Incoming files are allowed to have duplicate ids when records are in separate subcollections
  - Subcollections can define parameters (e.g. "provider_param: SPIE"). Specs adding fields can reference those parameters (e.g. "value: 'Content provider: provider_param.'). Fields are created for each record using the paramter values of the record's subcollection.