### PR TITLE
Handle non-utf8 string comparison

### DIFF
--- a/lib/marc_wrangler/version.rb
+++ b/lib/marc_wrangler/version.rb
@@ -1,3 +1,3 @@
 module MarcWrangler
-  VERSION = '0.1.2.2'.freeze
+  VERSION = '0.1.3'.freeze
 end

--- a/marc_wrangler.gemspec
+++ b/marc_wrangler.gemspec
@@ -37,4 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'highline', "~> 2.0.1"
   spec.add_runtime_dependency 'marc', "~> 1.0.2"
   spec.add_runtime_dependency 'enhanced_marc', "~> 0.3.2"
+
+  # unf_ext 0.0.7.6 was released without windows binaries
+  spec.add_runtime_dependency 'unf_ext', "0.0.7.5"
 end

--- a/spec/comparable_fields_spec.rb
+++ b/spec/comparable_fields_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe MarcWrangler::ComparableField do
+  describe '#norm_string' do
+    xit 'normalizes utf-8 strings' do
+    end
+
+    it 'also handles marc-8 encoded strings' do
+      marc8 = "$c\xC32008"
+      expect(described_class.norm_string(marc8)).to eq('$c©2008')
+    end
+
+    context 'string is not valid utf-8 or marc-8' do
+      it 'returns original, unnormalized, string' do
+        str = "\xC8"
+        expect(described_class.norm_string(str)).to eq(str)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When normalizing field contents for comparison AND the contents include
invalid utf-8 byte encodings, try to transcode the string from marc-8 to
utf-8 before continuing with the normalization. When the string is also
not valid marc-8, use the unnormalized string for comparison.