### PR TITLE
APPDEV-11094: WCM no AC fields

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7]
+        ruby: [2.7, 3.0, 3.1, 3.2]
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/config.yaml
+++ b/config.yaml
@@ -113,7 +113,6 @@ workflows:
       #   replace: ''
     use id affix: false
     use existing record set: false
-    elvl sets AC status: false
     write format flag to recs: true
     check LDR/09 for in-set consistency: true
     write warnings to recs: true
@@ -160,7 +159,6 @@ workflows:
       NEW: '_in_new_only'
     produce delete file: true
     report delete count on screen: true
-    elvl sets AC status: false
     write format flag to recs: false
     check LDR/09 for in-set consistency: false
     write warnings to recs: false
@@ -222,10 +220,6 @@ workflows:
       NEW: '_prep_for_load'
     produce delete file: true
     report delete count on screen: true
-    elvl sets AC status: true
-    add AC MARC fields: false
-    add noAC MARC fields: true
-    flag AC recs with changed headings: true
     write format flag to recs: true
     warn about non-e-resource records: true
     warn about cat lang: true
@@ -256,10 +250,6 @@ workflows:
     set record status by file diff: false
     flag rec status: false
     produce delete file: false
-    elvl sets AC status: true
-    add AC MARC fields: false
-    add noAC MARC fields: true
-    flag AC recs with changed headings: false
 
   WCM - compare current downloadable full set against current ILS set:
     clean ids:
@@ -337,10 +327,6 @@ workflows:
       NEW: '_prep_for_load'
     produce delete file: true
     report delete count on screen: true
-    elvl sets AC status: true
-    add AC MARC fields: false
-    add noAC MARC fields: true
-    flag AC recs with changed headings: true
 
   OHO pre-edit:
     use existing record set: true
@@ -494,18 +480,6 @@ collections:
         subfields:
           - delimiter: 'f'
             value: 'Unlimited simultaneous users'
-      - tag: '915'
-        i1: ' '
-        i2: ' '
-        subfields:
-          - delimiter: '9'
-            value: 'NOTAUTHO'
-      - tag: '949'
-        i1: ' '
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: '*b3=x'
     subcollection spec:
       set by:
         tag: '773'
@@ -521,10 +495,6 @@ collections:
         JSTOR:
           value: 'JSTOR .*(online collection)'
           provider_param: 'JSTOR'
-    elvl sets AC status: false
-    add AC MARC fields: false
-    add noAC MARC fields: false
-    flag AC recs with changed headings: false
   WCM - AGU:
     id affix value: 'AGU'
     add MARC field spec:
@@ -755,19 +725,4 @@ collections:
         subfields:
           - delimiter: 'a'
             value: 'Provider: Wiley.'
-      - tag: '915'
-        i1: ' '
-        i2: ' '
-        subfields:
-          - delimiter: '9'
-            value: 'NOTAUTHO'
-      - tag: '949'
-        i1: ' '
-        i2: ' '
-        subfields:
-          - delimiter: 'a'
-            value: '*b3=x'
-    elvl sets AC status: false
-    add noAC MARC fields: true
-    flag AC recs with changed headings: false
 

--- a/lib/marc_wrangler/record_comparer.rb
+++ b/lib/marc_wrangler/record_comparer.rb
@@ -7,11 +7,8 @@ module MarcWrangler
 
       @changed = detect_change(comparable_in_fields, comparable_ex_fields)
 
-      output_static = @spec['incoming record output files'] &&
-                      @spec['incoming record output files']['STATIC'] != 'do not output'
-      return unless @changed || output_static
-
-      @ac_change = detect_ac_change(ac_in_fields, ac_ex_fields)
+      @output_static = @spec['incoming record output files'] &&
+                       @spec['incoming record output files']['STATIC'] != 'do not output'
     end
 
     def static?
@@ -31,7 +28,11 @@ module MarcWrangler
     end
 
     def ac_change?
-      @ac_change
+      return @ac_change if @ac_change
+
+      return unless @changed || @output_static
+
+      @ac_change ||= detect_ac_change(ac_in_fields, ac_ex_fields)
     end
 
     def detect_ac_change(in_fields, ex_fields)

--- a/lib/marc_wrangler/version.rb
+++ b/lib/marc_wrangler/version.rb
@@ -1,3 +1,3 @@
 module MarcWrangler
-  VERSION = '0.1.5.1'.freeze
+  VERSION = '0.1.6'.freeze
 end

--- a/marc_wrangler.gemspec
+++ b/marc_wrangler.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
 
   spec.add_runtime_dependency 'highline', "~> 2.0.1"
-  spec.add_runtime_dependency 'marc', "~> 1.0.2"
+  spec.add_runtime_dependency 'marc', "~> 1.1"
   spec.add_runtime_dependency 'enhanced_marc', "~> 0.3.2"
 
   # unf_ext 0.0.7.6 was released without windows binaries


### PR DESCRIPTION
- UNC WCM workflows/collections do not add AC/noAC fields
- defer evaluation of `#ac_change?` unless/until needed
- Update dependencies for ruby 3 compatibility